### PR TITLE
Don't escape the command on Win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.0
 
 - Upgrade to `sb-npm-path@2.x` ( API BREAKING )
+- Fix a bug on Windows where it would crash for paths with spaces
 
 ## 2.0.5
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ async function exec(
   let parameters = givenParameters
   if (process.platform === 'win32' && !options.shell) {
     spawnOptions.windowsVerbatimArguments = true
+    // NOTE: Keep filePath and parameters as one item or it'll ressurect steelbrain/exec#36
     parameters = ['/s', '/c', `"${filePath} ${parameters.map(escape).join(' ')}"`]
     filePath = process.env.comspec || 'cmd.exe'
   }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ async function exec(
   let parameters = givenParameters
   if (process.platform === 'win32' && !options.shell) {
     spawnOptions.windowsVerbatimArguments = true
-    parameters = ['/s', '/c', `"${[filePath].concat(parameters).map(escape).join(' ')}"`]
+    parameters = ['/s', '/c', `"${filePath} ${parameters.map(escape).join(' ')}"`]
     filePath = process.env.comspec || 'cmd.exe'
   }
   delete spawnOptions.timeout


### PR DESCRIPTION
Escaping the command itself was causing issues with several programs.

Fixes #36.