### PR TITLE
Properly escape command if it needs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+# Changelog
+
+## 3.0.1
+
+- Correctly handle spaces in the program path
+
 ## 3.0.0
 
 - Upgrade to `sb-npm-path@2.x` ( API BREAKING )
-- Fix a bug on Windows where it would crash for paths with spaces
+- Fix a bug on Windows where it would run certain programs incorrectly
 
 ## 2.0.5
 
@@ -14,7 +20,7 @@
 
 ## 2.0.3
 
-- Bump `consistent-env` version to include bugfixes
+- Bump `consistent-env` version to include bug fixes
 
 ## 2.0.2
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,13 @@ async function exec(
   let parameters = givenParameters
   if (process.platform === 'win32' && !options.shell) {
     spawnOptions.windowsVerbatimArguments = true
-    // NOTE: Keep filePath and parameters as one item or it'll ressurect steelbrain/exec#36
-    parameters = ['/s', '/c', `"${filePath} ${parameters.map(escape).join(' ')}"`]
+    let cmdArgs = [filePath]
+    // filePath must be escaped if it has a \s in it, otherwise it must not
+    if (/\s/.test(filePath)) {
+      cmdArgs = cmdArgs.map(escape)
+    }
+    cmdArgs = cmdArgs.concat(parameters.map(escape))
+    parameters = ['/s', '/c', `"${cmdArgs.join(' ')}"`]
     filePath = process.env.comspec || 'cmd.exe'
   }
   delete spawnOptions.timeout


### PR DESCRIPTION
The command needs to be escaped if it has a \s in the path, but it _can't_ be escaped if it doesn't.

Fixes #36 (again).