### PR TITLE
Cleanup and fix the specs for win32

### DIFF
--- a/spec/fixtures/deep/node_modules/.bin/sb-exec-test.bat
+++ b/spec/fixtures/deep/node_modules/.bin/sb-exec-test.bat
@@ -1,0 +1,2 @@
+@echo off
+echo HEY2

--- a/spec/fixtures/node.js
+++ b/spec/fixtures/node.js
@@ -7,6 +7,5 @@ if (process.argv.indexOf('error') !== -1) {
 } else if (process.argv.indexOf('input') !== -1) {
   process.stdin.on('data', function(chunk) {
     process.stdout.write(chunk)
-    process.stdin.end()
   })
 }

--- a/spec/fixtures/path/node_modules/.bin/sb-exec-test.bat
+++ b/spec/fixtures/path/node_modules/.bin/sb-exec-test.bat
@@ -1,0 +1,2 @@
+@echo off
+echo HEY

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -80,28 +80,32 @@ describe('exec', function() {
     expect(result).toBe('')
   })
 
-  it('supports executing modules from local paths', async function() {
-    const result = await exec('sb-exec-test', [], { local: {
-      directory: Path.join(__dirname, 'fixtures', 'path'),
-    } })
-    expect(result).toBe('HEY')
-  })
-  it('supports prepend', async function() {
-    const PATH = Path.join(__dirname, 'fixtures', 'path', 'node_modules', '.bin')
-    const result = await exec('sb-exec-test', [], { local: {
-      directory: Path.join(__dirname, 'fixtures', 'deep'),
-      prepend: true,
-    },
-      env: { PATH } })
-    expect(result).toBe('HEY2')
-  })
-  it('supports append', async function() {
-    const PATH = Path.join(__dirname, 'fixtures', 'path', 'node_modules', '.bin')
-    const result = await exec('sb-exec-test', [], { local: {
-      directory: Path.join(__dirname, 'fixtures', 'deep'),
-    },
-      env: { PATH } })
-    expect(result).toBe('HEY')
+  describe('supports executing modules', function() {
+    it('from local paths', async function() {
+      const result = await exec('sb-exec-test', [], { local: {
+        directory: Path.join(__dirname, 'fixtures', 'path'),
+      } })
+      expect(result).toBe('HEY')
+    })
+
+    it('supports prepend', async function() {
+      const PATH = Path.join(__dirname, 'fixtures', 'path', 'node_modules', '.bin')
+      const result = await exec('sb-exec-test', [], { local: {
+        directory: Path.join(__dirname, 'fixtures', 'deep'),
+        prepend: true,
+      },
+        env: { PATH } })
+      expect(result).toBe('HEY2')
+    })
+
+    it('supports append', async function() {
+      const PATH = Path.join(__dirname, 'fixtures', 'path', 'node_modules', '.bin')
+      const result = await exec('sb-exec-test', [], { local: {
+        directory: Path.join(__dirname, 'fixtures', 'deep'),
+      },
+        env: { PATH } })
+      expect(result).toBe('HEY')
+    })
   })
 })
 

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -14,7 +14,7 @@ describe('exec', function() {
     expect(result).toBe('STDOUT')
   })
 
-  it('throws if we are expecting on stderr and get on stdout', async function() {
+  it('throws if we are expecting on stderr and get output on stdout', async function() {
     try {
       await exec(process.execPath, [PATH_NODE, 'error'])
       expect(false).toBe(true)
@@ -23,7 +23,7 @@ describe('exec', function() {
     }
   })
 
-  it('doesnt mind when we are expecting on stderr though', async function() {
+  it("doesn't mind when we are expecting on stderr though", async function() {
     const result = await exec(process.execPath, [PATH_NODE, 'error'], { stream: 'stderr' })
     expect(result).toBe('STDERR')
   })
@@ -44,12 +44,12 @@ describe('exec', function() {
     expect(result).toBe('STDOUT')
   })
 
-  it('acts like a good buy if script terminates before timeout', async function() {
+  it('acts like a good boy if script terminates before timeout', async function() {
     const result = await exec(process.execPath, [PATH_WAIT, '1000'], { timeout: 1500 })
     expect(result).toBe('PASSED')
   })
 
-  it('termintes the script and errors if the process times out', async function() {
+  it('terminates the script and errors if the process times out', async function() {
     try {
       await exec(process.execPath, [PATH_WAIT, '2000'], { timeout: 1000 })
       expect(false).toBe(true)
@@ -120,15 +120,18 @@ describe('execNode', function() {
       expect(_.message).toContain('code: 2')
     }
   })
+
   it('does not cry if stream is stdout, exit code is non-zero and ignoreExitCode is set to true', async function() {
     const path = Path.join(__dirname, 'fixtures', 'non-zero.js')
     await execNode(path, [], { ignoreExitCode: true })
   })
+
   it('returns exitCode for `both` streams', async function() {
     const path = Path.join(__dirname, 'fixtures', 'non-zero.js')
     const output = await execNode(path, [], { stream: 'both' })
     expect(output.exitCode).toBe(2)
   })
+
   it('throws if stream is `stderr` and the output is empty', async function() {
     const path = Path.join(__dirname, 'fixtures', 'non-zero.js')
     try {
@@ -139,11 +142,13 @@ describe('execNode', function() {
       expect(_.message).toContain('with no output')
     }
   })
+
   it('does not throw on `stderr` if the output is empty and allowEmptyStderr is set to false', async function() {
     const path = Path.join(__dirname, 'fixtures', 'non-zero.js')
     const output = await execNode(path, [], { stream: 'stderr', allowEmptyStderr: true })
     expect(output).toBe('')
   })
+
   it('automatically converts non-stringish parameters to string', async function() {
     const path = Path.join(__dirname, 'fixtures', 'env-coerce.js')
     const output = await execNode(path, [2, 3, 2.2, false])
@@ -152,11 +157,12 @@ describe('execNode', function() {
 })
 
 if (process.platform === 'win32') {
-  describe('Fixes for windows', function() {
+  describe('works on Windows', function() {
     it('works with paths that have spaces in name', async function() {
       const result = await exec(Path.join(__dirname, './fixtures/yes spaces/hello.exe'))
       expect(result).toBe('Hello World')
     })
+
     it('works with paths without pathext', async function() {
       const result = await exec(Path.join(__dirname, './fixtures/yes spaces/hello'))
       expect(result).toBe('Hello World')


### PR DESCRIPTION
Make the specs run on Windows again in preparation for enabling AppVeyor CI builds.