### PR TITLE
Specify that timeout is in milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install --save sb-exec
 
 ```js
 type $OptionsAccepted = {
-  timeout?: number | Infinity,
+  timeout?: number | Infinity, // In milliseconds
   stream?: 'stdout' | 'stderr'  | 'both',
   env: Object,
   stdin?: string | Buffer,


### PR DESCRIPTION
It's probably obvious, but it also saves people the extra step of checking the source code